### PR TITLE
Hide password input by default

### DIFF
--- a/ui/src/main/java/cz/ackee/ui/textfield/PasswordToggleEndIconDelegate.java
+++ b/ui/src/main/java/cz/ackee/ui/textfield/PasswordToggleEndIconDelegate.java
@@ -17,6 +17,7 @@
 package cz.ackee.ui.textfield;
 
 import android.text.Editable;
+import android.text.InputType;
 import android.text.TextWatcher;
 import android.text.method.PasswordTransformationMethod;
 import android.view.View;
@@ -105,11 +106,24 @@ class PasswordToggleEndIconDelegate extends EndIconDelegate {
         });
     textInputLayout.addOnEditTextAttachedListener(onEditTextAttachedListener);
     textInputLayout.addOnEndIconChangedListener(onEndIconChangedListener);
+    EditText editText = textInputLayout.getEditText();
+    if (isInputTypePassword(editText)) {
+      // By default set the input to be disguised.
+      editText.setTransformationMethod(PasswordTransformationMethod.getInstance());
+    }
   }
 
   private boolean hasPasswordTransformation() {
     EditText editText = textInputLayout.getEditText();
     return editText != null
         && editText.getTransformationMethod() instanceof PasswordTransformationMethod;
+  }
+
+  private static boolean isInputTypePassword(EditText editText) {
+    return editText != null
+            && (editText.getInputType() == InputType.TYPE_NUMBER_VARIATION_PASSWORD
+            || editText.getInputType() == InputType.TYPE_TEXT_VARIATION_PASSWORD
+            || editText.getInputType() == InputType.TYPE_TEXT_VARIATION_VISIBLE_PASSWORD
+            || editText.getInputType() == InputType.TYPE_TEXT_VARIATION_WEB_PASSWORD);
   }
 }


### PR DESCRIPTION
A password should be hidden by default when `EditText` is set to `TYPE_TEXT_VARIATION_PASSWORD` and
`TextInputLayout` uses `END_ICON_PASSWORD_TOGGLE`

The solution is copied from [Material Components 1.2.0-Alpha TextInputLayout](https://github.com/material-components/material-components-android/issues/491)